### PR TITLE
メール送信に関する機能作成

### DIFF
--- a/app/mail_sender.py
+++ b/app/mail_sender.py
@@ -1,0 +1,63 @@
+from requests import post
+from os import environ
+import json
+from uuid import uuid4
+
+
+def get_register_body() -> dict:
+    return {
+        "subject": "新規登録フォームの送信",
+        "message": f"下記のURLから新規登録を行なってください。\n"
+                   f"{environ.get('REGISTER_URL')}"
+    }
+
+
+def get_confirm_register_body() -> dict:
+    return {
+        "subject": "新規登録完了",
+        "message": "Find Flightsをご利用いただきありがとうございます。\n"
+                   "新規登録が完了しました。"
+    }
+
+
+def get_update_email_body() -> dict:
+    return {
+        "subject": "メールアドレスの更新",
+        "message": "Find Flightsをご利用いただきありがとうございます\n"
+                   "下記のURLにアクセスしていただくことでメールアドレスの更新が完了します。\n"
+                   f"{environ.get('UPDATE_URL')}"
+    }
+
+
+class EmailSender(object):
+    def __init__(self, recipient, action):
+        self.api_key = environ.get("MAIL_API_KEY")
+        self.domain_name = environ.get("MAIL_DOMAIN_NAME")
+        self.recipient = recipient
+        if action == "register":
+            self.body = get_register_body()
+            self.append_token()
+        elif action == "update_email":
+            self.body = get_update_email_body()
+            self.append_token()
+        elif action == "confirm_register":
+            self.body = get_confirm_register_body()
+
+    def append_token(self) -> None:
+        token = uuid4().hex
+        self.body["message"] += token
+
+    def send(self) -> (int, str):
+        response = post(
+            url=f"https://api.mailgun.net/v3/{self.domain_name}/messages",
+            auth=("api", self.api_key),
+            data={
+                "from": f"Find Flights管理者 <customer_srvice@{self.domain_name}>",
+                "to": self.recipient,
+                "subject": self.body["subject"],
+                "text": self.body["message"]
+            }
+        )
+        status_code = response.status_code
+        response_message = json.loads(response.text)["message"]
+        return status_code, response_message

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,35 @@
+import threading
+import uvicorn
+from fastapi import FastAPI
+from rabbitmq import consume
+from threading import Thread
+from logging import getLogger
+
+app = FastAPI()
+logger = getLogger("uvicorn")
+
+
+@app.on_event("shutdown")
+def terminate_threads() -> None:
+    for thread in threading.enumerate():
+        if thread is threading.current_thread():
+            continue
+        thread.join()
+
+
+if __name__ == "__main__":
+    queue_name_and_action = (
+        ("register_mail_queue", "register"),
+        ("update_mail_queue", "update_email"),
+        ("confirm_register_queue", "confirm_register")
+    )
+
+    threads_list = []
+    for thread_arg in queue_name_and_action:
+        thread = Thread(target=consume, args=thread_arg, daemon=True)
+        threads_list.append(thread)
+
+    for thread in threads_list:
+        thread.start()
+
+    uvicorn.run("main:app", host="0.0.0.0", port=5001, reload=True)

--- a/app/rabbitmq.py
+++ b/app/rabbitmq.py
@@ -1,0 +1,56 @@
+import pika
+from os import environ
+from logging import getLogger
+from mail_sender import EmailSender
+from functools import partial
+
+logger = getLogger("uvicorn")
+
+
+def callback(ch, method, properties, body, queue_name: str,
+             action: str) -> None:
+    mail_address = body.decode()
+    logger.info(f"Received {mail_address} from {queue_name}.")
+    mail_sender = EmailSender(recipient=mail_address, action=action)
+    status_code, message = mail_sender.send()
+    if status_code == 200:
+        logger.info(f"Succeeded in sending email to {mail_address}")
+    else:
+        logger.error(
+            f"Failed to send email to {mail_address}."
+            f"Error code: {status_code}, error message: {message}"
+        )
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+
+
+def consume(queue_name: str, action: str) -> None:
+    user = environ.get("RABBITMQ_USER")
+    password = environ.get("RABBITMQ_PASSWORD")
+    host = environ.get("RABBITMQ_HOST")
+    port = environ.get("RABBITMQ_PORT")
+
+    try:
+        params = pika.URLParameters(f"amqp://{user}:{password}@{host}:{port}")
+        connection = pika.BlockingConnection(params)
+    except NameError as e:
+        logger.error(f"Failed to connect to RabbitMQ. {type(e)}: {e}")
+        return
+    except RuntimeError as e:
+        logger.error(f"Failed to connect to RabbitMQ. {type(e)}: {e}")
+        return
+
+    channel = connection.channel()
+    channel.queue_declare(queue=queue_name, durable=True)
+    print(f"Waiting for messages from {queue_name}.")
+    channel.basic_qos(prefetch_count=1)
+    # partial関数のドキュメントURL
+    # https://docs.python.org/3/library/functools.html#functools.partial
+    callback_with_arguments = partial(
+        callback, queue_name=queue_name, action=action
+    )
+
+    channel.basic_consume(
+        queue=queue_name, on_message_callback=callback_with_arguments
+    )
+
+    channel.start_consuming()


### PR DESCRIPTION
## メール送信機能
app/mail_sender.pyで`EmailSender class`を定義。
MailgunのAPIを使用してメール送信を行う。
API使用時の認証情報は環境変数から`MAIL_API_KEY`と`MAIL_DOMAIN_NAME`として取得する。
ユーザー登録時(`action="register"`)とメールアドレス変更時(`action="update_email"`)は、`append_token`メソッドでuuidライブラリを使用して認証トークンを発行し、メール本文の認証用URLの最後にクエリーパラメータとして追加する。認証トークンはclient serviceからの問い合わせで使用予定。
## message consumer
app/rabbitmq.pyでmessageのconsumerとして`consume`関数を作成。
message受信時、channelの`basic_consume`メソッドではcallback関数を実行できるが、初期設定ではcallback関数の引数は`(channel, method, properties, body)`の４つのみで追加の引数が渡せない。そこで、標準ライブラリのfuctoolsから`partial`関数を使用し追加で引数を渡せるようにして、`queue_name`と`action`２つの引数を渡して実行できるようにした。
callback 関数では`EmailSender`から帰ってきた`status_code`に応じてログを作成する。
## Multi threading
app/main.pyではuvicornを実行するMain threadの他に、`consume`関数を実行する3つのthreadを実行する。
28行目から始まるforループ内でthreadの`start`メソッドを実行すると、プログラム終了時にゾンビプロセスが発生する。1つのforループ内で`start`メソッドまで実行するとゾンビプロセスが発生する理由は現在のところ判明していない。そのため、32行目から始まるforループで`start`メソッドを実行している。
プログラム終了時、FastAPIのon_eventメソッドでMain thread以外のthreadを`join`して、プログラムを終了する